### PR TITLE
Feat/donotdisplay

### DIFF
--- a/HAL/classes/settings.py
+++ b/HAL/classes/settings.py
@@ -48,6 +48,7 @@ DATA_DEFAULTS = {
 
 METADATA_DEFAULTS = {
     "autorefresh cache": True,
+    "do not display": "com_x, com_y"
 }
 
 FIT_DEFAULTS = {

--- a/HAL/default_modules/metadata/fit.py
+++ b/HAL/default_modules/metadata/fit.py
@@ -11,7 +11,7 @@ Comments : Imports fit information, as saved by HAL
 
 import json
 from pathlib import Path
-
+from ...classes.settings import Settings
 # -- local
 from HAL.classes.metadata.abstract import AbstractMetaData
 
@@ -30,6 +30,10 @@ class HALFitData(AbstractMetaData):
         # - general
         self.name = "fit"
         self.path = path
+        self._settings_folder = Path().home() / ".HAL"
+        global_config_path = self._settings_folder / "global.conf"
+        self.settings = Settings(path=global_config_path)
+
 
     def analyze(self):
         # - init / reset data
@@ -92,10 +96,17 @@ class HALFitData(AbstractMetaData):
         # - get values
         fit_collection = json_data["collection"]
         for roi, fitres in fit_collection.items():
+            #do_not_display = self.settings.config["metadata"]["do not display"].split(", ")
+            #print(do_not_display)
             for value in fitres["result"]["values"]:
                 param = {k: v for k, v in value.items()}
-                param["name"] = "%s::%s" % (roi, value["name"])
-                data.append(param)
+                #print(self.settings.config["metadata"]["do not display"])
+                do_not_display = ["com_x", "com_y"]
+                if param["name"] in do_not_display:
+                    pass
+                else:
+                    param["name"] = "%s::%s" % (roi, value["name"])
+                    data.append(param)
         # - store
         self.data = data
 

--- a/HAL/default_modules/metadata/fit.py
+++ b/HAL/default_modules/metadata/fit.py
@@ -96,12 +96,12 @@ class HALFitData(AbstractMetaData):
         # - get values
         fit_collection = json_data["collection"]
         for roi, fitres in fit_collection.items():
-            #do_not_display = self.settings.config["metadata"]["do not display"].split(", ")
+            do_not_display = self.settings.config["metadata"]["do not display"].split(", ")
             #print(do_not_display)
             for value in fitres["result"]["values"]:
                 param = {k: v for k, v in value.items()}
                 #print(self.settings.config["metadata"]["do not display"])
-                do_not_display = ["com_x", "com_y"]
+                #do_not_display = ["com_x", "com_y"]
                 if param["name"] in do_not_display:
                     pass
                 else:

--- a/HAL/default_modules/metadata/fit.py
+++ b/HAL/default_modules/metadata/fit.py
@@ -12,6 +12,7 @@ Comments : Imports fit information, as saved by HAL
 import json
 from pathlib import Path
 from ...classes.settings import Settings
+
 # -- local
 from HAL.classes.metadata.abstract import AbstractMetaData
 
@@ -33,7 +34,6 @@ class HALFitData(AbstractMetaData):
         self._settings_folder = Path().home() / ".HAL"
         global_config_path = self._settings_folder / "global.conf"
         self.settings = Settings(path=global_config_path)
-
 
     def analyze(self):
         # - init / reset data
@@ -96,7 +96,9 @@ class HALFitData(AbstractMetaData):
         # - get values
         fit_collection = json_data["collection"]
         for roi, fitres in fit_collection.items():
-            do_not_display = self.settings.config["metadata"]["do not display"].split(", ")
+            do_not_display = self.settings.config["metadata"]["do not display"].split(
+                ", "
+            )
             for value in fitres["result"]["values"]:
                 param = {k: v for k, v in value.items()}
                 if param["name"] in do_not_display:

--- a/HAL/default_modules/metadata/fit.py
+++ b/HAL/default_modules/metadata/fit.py
@@ -97,11 +97,8 @@ class HALFitData(AbstractMetaData):
         fit_collection = json_data["collection"]
         for roi, fitres in fit_collection.items():
             do_not_display = self.settings.config["metadata"]["do not display"].split(", ")
-            #print(do_not_display)
             for value in fitres["result"]["values"]:
                 param = {k: v for k, v in value.items()}
-                #print(self.settings.config["metadata"]["do not display"])
-                #do_not_display = ["com_x", "com_y"]
                 if param["name"] in do_not_display:
                     pass
                 else:


### PR DESCRIPTION
This is a quick update in order to display only a few parameters from the fit results in the metadata bar, for a visibility purpose.  The config file is used to specify which parameters the user does not want to display.